### PR TITLE
Added support for dynamic noise_shape in Dropout

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -97,8 +97,11 @@ class Dropout(Layer):
         self.seed = seed
         self.supports_masking = True
 
-    def _get_noise_shape(self, _):
-        return self.noise_shape
+    def _get_noise_shape(self, inputs):
+        symbolic_shape = K.shape(inputs)
+        noise_shape = [shape if shape > 0 else symbolic_shape[axis]
+                       for axis, shape in enumerate(self.noise_shape)]
+        return tuple(noise_shape)
 
     def call(self, inputs, training=None):
         if 0. < self.rate < 1.:
@@ -112,7 +115,9 @@ class Dropout(Layer):
         return inputs
 
     def get_config(self):
-        config = {'rate': self.rate}
+        config = {'rate': self.rate,
+                  'noise_shape': self.noise_shape,
+                  'seed': self.seed}
         base_config = super(Dropout, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 


### PR DESCRIPTION
Dropout didn't have support for dynamic noise_shape inference and batch size had to be fixed which was breaking the model after save/loading. Now it's possible to write noise_shape=(None, 1, None) for instance